### PR TITLE
fall back to 'auto' instead of '0' when fixHeight is undefined

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -182,7 +182,7 @@ class Shiitake extends React.Component {
       vertSpacers.push(<span style={block} key={i}>W</span>);
     }
 
-    const thisHeight = (fixHeight || 0) + 'px';
+    const thisHeight = fixHeight ? `${fixHeight}px` : 'auto';
     const maxHeight = (renderFullOnServer) ? '' : thisHeight;
 
     const overflow = (testChildren.length < this.state.allChildren.length) ? overflowNode : null;


### PR DESCRIPTION
thanks for the great component.

sometimes the truncated text doesn't even appear because of that line